### PR TITLE
Add a pair of Github Actions

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -1,0 +1,35 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Pull Request Builds
+
+on:
+  pull_request:
+    paths:
+    - "src/**"
+
+jobs:
+  Build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - name: Grant execute permission to gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: "Compiled artifacts for Pull Request #${{github.event.number}}"
+        path: build/libs

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -1,0 +1,35 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Development Builds
+
+on:
+  push:
+    paths:
+    - "src/**"
+
+jobs:
+  Build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - name: Grant execute permission to gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Compiled artifacts for ${{ github.sha }}
+        path: build/libs


### PR DESCRIPTION
Literally the same 2 basic ones from Carpet.

These two actions basically build every commit pushed to the repo, so it can quickly highlight failures, plus build PRs so you can merge knowing it at least builds, instead of merge then suddenly see it horribly fails.

I _may_ at some point PR some automation for the `README` generation (that is, run your script directly on Github instead of manually whenever there is a release, nothing really too fancy), but it would be my first Python action.

BTW First fork!

_Edit:_ Should I have targeted the `development` branch instead? If so, feel free to change it (edit button at the top right)